### PR TITLE
Extract custom concepts from the file

### DIFF
--- a/src/lib/components/Types.d.ts
+++ b/src/lib/components/Types.d.ts
@@ -255,6 +255,8 @@ export interface IUsagiMappedCols {
   conceptId?: number | null
   conceptName?: string | null
   domainId?: string | null
+  vocabulary?: string | null
+  className?: string | null
   sourceAutoAssignedConceptIds?: string | null
 }
 

--- a/src/lib/components/mapping/AthenaSearch.svelte
+++ b/src/lib/components/mapping/AthenaSearch.svelte
@@ -126,6 +126,9 @@
     const update: IUsagiAllExtra = {
       conceptId: customConcept.conceptId,
       conceptName: customConcept.conceptName,
+      domainId: customConcept.domainId,
+      vocabulary: customConcept.vocabularyId,
+      className: customConcept.conceptClassId,
       comment,
       assignedReviewer: reviewer,
       mappingStatus: 'SEMI-APPROVED',

--- a/src/lib/components/mapping/views/MappedView.svelte
+++ b/src/lib/components/mapping/views/MappedView.svelte
@@ -24,9 +24,9 @@
         <button on:click={() => removeMapping(renderedRow)}><SvgIcon id="x" /></button>
       {/if}
     </td>
-    {#each Object.keys(renderedRow) as key}
+    {#each columns as column}
       <td>
-        <p>{renderedRow[key]}</p>
+        <p>{renderedRow[column.id]}</p>
       </td>
     {/each}
   </DataTable>

--- a/src/lib/data/columnsUsagi.json
+++ b/src/lib/data/columnsUsagi.json
@@ -30,18 +30,28 @@
     "editable": false
   },
   {
+    "id": "mappingStatus",
+    "visible": true,
+    "editable": false
+  },
+  {
     "id": "domainId",
+    "visible": true,
+    "editable": false
+  },
+  {
+    "id": "vocabulary",
+    "visible": true,
+    "editable": false
+  },
+  {
+    "id": "className",
     "visible": false,
     "editable": false
   },
   {
     "id": "matchScore",
     "visible": false,
-    "editable": false
-  },
-  {
-    "id": "mappingStatus",
-    "visible": true,
     "editable": false
   },
   {

--- a/src/lib/implementations/databaseImpl/LocalImpl.ts
+++ b/src/lib/implementations/databaseImpl/LocalImpl.ts
@@ -32,7 +32,7 @@ export default class LocalImpl implements IUpdatedFunctionalityImpl {
     return files
   }
 
-  async getFilesAdmin(): Promise<IFile[] | void> { }
+  async getFilesAdmin(): Promise<IFile[] | void> {}
 
   async uploadFile(file: File, authors: string[]): Promise<string[] | void> {
     if (dev) console.log('uploadFile: Uploading file to IndexedDB')
@@ -46,7 +46,13 @@ export default class LocalImpl implements IUpdatedFunctionalityImpl {
       'concept_id,concept_name,domain_id,vocabulary_id,concept_class_id,standard_concept,concept_code,valid_start_date,valid_end_date,invalid_reason\n0,test,test,test,test,S,123,2000-01-01,2099-01-01,U',
     ])
     const customFileString = await blobToString(customBlob)
-    const customFileContent: IFile = { id: fileId, name: `${file.name.split('.')[0]}_concepts.csv`, authors: [], version: 1, content: customFileString }
+    const customFileContent: IFile = {
+      id: fileId,
+      name: `${file.name.split('.')[0]}_concepts.csv`,
+      authors: [],
+      version: 1,
+      content: customFileString,
+    }
     await this.openCustomDatabase()
     await this.customDb!.set(customFileContent, fileId, true)
     // goto(`${base}/mapping&id=${fileId}`)
@@ -58,18 +64,30 @@ export default class LocalImpl implements IUpdatedFunctionalityImpl {
     const fileInfo: IFile | undefined = await this.db?.get(id, true)
     if (!fileInfo) return console.error(`editFile: No file found with id ${id}`)
     const fileString = await blobToString(blob)
-    const fileContent: IFile = { id, name: fileInfo.name, authors: [], version: fileInfo.version++, content: fileString }
+    const fileContent: IFile = {
+      id,
+      name: fileInfo.name,
+      authors: [],
+      version: fileInfo.version++,
+      content: fileString,
+    }
     await this.db?.set(fileContent, id, true)
     if (!customBlob) return
     await this.openCustomDatabase()
     const customFileInfo: IFile | undefined = await this.customDb?.get(id, true)
     if (!customFileInfo) return console.error(`editFile: No custom file foun with id ${id}`)
     const customFileString = await blobToString(customBlob)
-    const customFileContent: IFile = { id, name: fileInfo.name, authors: [], version: customFileInfo.version++, content: customFileString }
+    const customFileContent: IFile = {
+      id,
+      name: fileInfo.name,
+      authors: [],
+      version: customFileInfo.version++,
+      content: customFileString,
+    }
     await this.customDb?.set(customFileContent, id, true)
   }
 
-  async editFileAuthors(id: string, authors: string[]): Promise<void> { }
+  async editFileAuthors(id: string, authors: string[]): Promise<void> {}
 
   async deleteFile(id: string): Promise<void> {
     if (dev) console.log(`deleteFile: Delete the file with id ${id} in IndexedDB`)
@@ -104,9 +122,9 @@ export default class LocalImpl implements IUpdatedFunctionalityImpl {
     await this.download(updatedName, customFile)
   }
 
-  async getAllAuthors(): Promise<void | IUserRestriction> { }
+  async getAllAuthors(): Promise<void | IUserRestriction> {}
 
-  async watchValueFromDatabase(path: string, subCallback: () => unknown): Promise<void> { }
+  async watchValueFromDatabase(path: string, subCallback: () => unknown): Promise<void> {}
 
   private async openDatabase(): Promise<void> {
     if ((await this.isOpen(this.db)) == false) this.db = new IndexedDB('localMapping', 'localMapping')

--- a/src/lib/mappingUtils.ts
+++ b/src/lib/mappingUtils.ts
@@ -34,6 +34,8 @@ export async function resetRow() {
     const reset: IUsagiAllExtra = additionalFields
     reset.conceptId = null
     reset.domainId = null
+    reset.vocabulary = null
+    reset.className = null
     reset.conceptName = null
     delete reset.sourceAutoAssignedConceptIds
     return reset

--- a/src/routes/mapping/+page.svelte
+++ b/src/routes/mapping/+page.svelte
@@ -10,7 +10,7 @@
   import DataTable from '@radar-azdelta/svelte-datatable'
   // @ts-ignore
   import { LatencyOptimisedTranslator } from '@browsermt/bergamot-translator/translator.js'
-  import { stringToFile } from '$lib/utils'
+  import { reformatDate, stringToFile } from '$lib/utils'
   import { addExtraFields } from '$lib/mappingUtils'
   import { abortAutoMapping, customFileTypeImpl, databaseImpl, fileTypeImpl, saveImpl } from '$lib/store'
   import { selectedFileId, settings, translator, triggerAutoMapping, user } from '$lib/store'
@@ -23,14 +23,21 @@
   import columnsCustomConcept from '$lib/data/columnsCustomConcept.json'
   import AthenaSearch from '$lib/components/mapping/AthenaSearch.svelte'
   import UsagiRow from '$lib/components/mapping/UsagiRow.svelte'
-  import type { IAthenaRow, IMapRow, IUsagiRow, NavigateRowEventDetail } from '$lib/components/Types'
+  import type {
+    IAthenaRow,
+    ICustomConceptInput,
+    IMapRow,
+    IUsagiRow,
+    NavigateRowEventDetail,
+  } from '$lib/components/Types'
   import type { MappingEventDetail, AutoMapRowEventDetail, RowSelectionEventDetail } from '$lib/components/Types'
 
   // General variables
   let file: File | undefined = undefined,
     customConceptsFile: File | undefined = undefined,
     customTableOptions: ITableOptions = { id: 'customConceptsTable', saveOptions: false },
-    disabled: boolean = false
+    disabled: boolean = false,
+    customsExtracted: boolean = false
 
   let tableOptions: ITableOptions = {
     id: $page.url.searchParams.get('id') ? $page.url.searchParams.get('id')! : '',
@@ -82,7 +89,6 @@
     mappedRow.statusSetBy = $user.name
     mappedRow.statusSetOn = Date.now()
     mappedRow.mappingStatus = 'SEMI-APPROVED'
-
     // Update the selected row to the updated row
     await dataTableMapping.updateRows(new Map([[mappedIndex, mappedRow]]))
   }
@@ -160,7 +166,7 @@
     if ($translator) return $translator
     $translator = new LatencyOptimisedTranslator(
       { workers: 1, batchSize: 1, registryUrl: 'bergamot/registry.json', html: true },
-      undefined
+      undefined,
     )
     return $translator
   }
@@ -206,7 +212,7 @@
     usagiRow: IUsagiRow,
     athenaRow: IAthenaRow,
     autoMap = false,
-    index?: number
+    index?: number,
   ): Promise<IMapRow> {
     let rowIndex: number = index ? index : selectedRowIndex
     if (dev) console.log('rowMapping: Start mapping row with index ', rowIndex)
@@ -216,9 +222,38 @@
     mappedUsagiRow.conceptId = athenaRow.id
     mappedUsagiRow.conceptName = athenaRow.name
     mappedUsagiRow.domainId = athenaRow.domain
+    mappedUsagiRow.vocabulary = athenaRow.vocabulary
+    mappedUsagiRow.className = athenaRow.className
     mappedUsagiRow = await addExtraFields(mappedUsagiRow, autoMap)
     if (dev) console.log('rowMapping: Finished mapping row with index ', rowIndex)
     return { mappedIndex: rowIndex, mappedRow: mappedUsagiRow }
+  }
+
+  async function extractCustomConcepts(): Promise<void | boolean> {
+    if (dev) console.log('exractCustomConcepts: start extracting the already mapped custom concepts from the table')
+    const customQuery = query()
+      .filter((r: any) => r['ADD_INFO:customConcept'] === true && r.conceptId === 0)
+      .toObject()
+    const concepts = await dataTableMapping.executeQueryAndReturnResults(customQuery)
+    if (!concepts?.indices?.length) return (customsExtracted = true)
+    const testRow = await dataTableCustomConcepts.getFullRow(0)
+    if (testRow?.domain_id === 'test') await dataTableCustomConcepts.deleteRows([0])
+    for (let concept of concepts.queriedData) {
+      const custom: ICustomConceptInput = {
+        concept_id: concept.conceptId,
+        concept_code: concept.sourceName,
+        concept_name: concept.conceptName,
+        concept_class_id: concept.className,
+        domain_id: concept.domainId,
+        vocabulary_id: concept.vocabulary,
+        standard_concept: '',
+        valid_start_date: reformatDate(),
+        valid_end_date: '2099-12-31',
+        invalid_reason: '',
+      }
+      await dataTableCustomConcepts.insertRows([custom])
+    }
+    customsExtracted = true
   }
 
   // Abort the automapping that is happening
@@ -236,6 +271,7 @@
 
   // Start the automapping of all the visible rows, but create an abortcontroller to be able to stop the automapping at any moment
   async function autoMapPage(): Promise<void> {
+    if (!customsExtracted) await extractCustomConcepts()
     if (!$settings?.autoMap) return
     if (dev) console.log('autoMapPage: Starting auto mapping')
     // Abort any automapping that is happening at the moment


### PR DESCRIPTION
When importing an already mapped file with custom concepts in it, it will now extract those custom concepts in the setup.
This will be done to include those custom concepts in the _concepts file when downloading the file.

Otherwise you would have for example 3 custom concepts files when working on the file 3 seperate times.